### PR TITLE
[RFR-246] Add workaround for flaky rebind on Android 13+

### DIFF
--- a/measuring-client/src/main/java/de/cyface/app/ui/button/DataCapturingButton.java
+++ b/measuring-client/src/main/java/de/cyface/app/ui/button/DataCapturingButton.java
@@ -502,13 +502,11 @@ public class DataCapturingButton
             // - Don't wait for `shutDownFinished` to be called (flaky due to the bug).
             // - Use a static 500ms delay to give the measurement some time to stop.
             if (Build.VERSION.SDK_INT >= 33) {
-                setButtonStatus(button, PAUSED); // avoids button to flip to "stopped" before "paused"
                 final var timeoutHandler = new Handler(context.getMainLooper());
                 timeoutHandler.postAtTime(() -> {
                     // The measurement id should always be set [STAD-333]
                     // Validate.isTrue(measurementIdentifier != -1, "Missing measurement id");
-                    // Avoids button to flip to "stopped" before "paused"
-                    // setButtonStatus(button, PAUSED);
+                    setButtonStatus(button, PAUSED);
                     setButtonEnabled(button);
                     Toast.makeText(context, R.string.toast_measurement_paused, Toast.LENGTH_SHORT).show();
                 }, SystemClock.uptimeMillis() + 500L);
@@ -1056,7 +1054,10 @@ public class DataCapturingButton
 
     @Override
     public void onCapturingStopped() {
-        setButtonStatus(button, FINISHED);
+        // Disabled on Android 13+ for workaround, see `stop/pauseCapturing()` [RFR-246]
+        if (Build.VERSION.SDK_INT < 33) {
+            setButtonStatus(button, FINISHED);
+        }
     }
 
     /*


### PR DESCRIPTION
This PR adds a workaround for the flaky `rebind` on Android 13.

It seems like this is a bug on Android 13, as the `rebind()`ing between `DataCapturingService` and `BackgroundDataCapturingService` works perfectly until Android 12 (Pixel 3a) but stops working on Android 13 (Pixel 6) after ~20-30 minutes of capturing in background (display disabled). The bug is independent from `targetVersion` which usually determines behavioral changes.