### PR TITLE
[STAD-435] Move CI to Github Actions

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -1,0 +1,57 @@
+# This workflow ensures the building step works
+#
+# @author Armin Schnabel
+# @version 1.0.0
+# @since 3.2.0
+name: Gradle Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        # Does not work out of the box with a private repository
+        # see https://github.com/actions/checkout/issues/287
+        #with:
+        #  submodules: true
+      - name: Add SSH private keys for submodule repositories
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          # This allows to add multiple individual deploy keys for multiple private submodules
+          # for a guide, see https://github.com/marketplace/actions/webfactory-ssh-agent
+          ssh-private-key: |
+            ${{ secrets.SSH_DEPLOY_KEY_CAMERA_SERVICE }}
+      - run: git submodule update --init --recursive
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Add gradle.properties
+        run: |
+          # Use a personal read token to install the Cyface Utils package
+          cp gradle.properties.template gradle.properties
+          echo "githubUser=${{ secrets.GH_READ_ACCOUNT }}" >> gradle.properties
+          echo "githubToken=${{ secrets.GH_READ_TOKEN }}" >> gradle.properties
+          # This mock API accepts all credentials and allows the UI test to skip the login
+          echo "cyface.staging_api=https://demo.cyface.de/api/v2" >> gradle.properties
+          echo "cyface.staging_user=guestLogin" >> gradle.properties
+          echo "cyface.staging_password=guestPassword" >> gradle.properties
+
+      # Executing build here on Ubuntu stack (1/10th costs of MacOS stack)
+      # Not using "gradle build" as we don't want to run the tests of all dependencies (e.g. backend)
+      - name: Assemble with Gradle
+        run: ./gradlew :measuring-client:assembleDebug
+      - name: Test with Gradle
+        run: ./gradlew :measuring-client:testDebugUnitTest

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -18,19 +18,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
         # Does not work out of the box with a private repository
         # see https://github.com/actions/checkout/issues/287
         #with:
         #  submodules: true
-      - name: Add SSH private keys for submodule repositories
+      - name: Link Deploy Keys for Submodules
         uses: webfactory/ssh-agent@v0.7.0
         with:
           # This allows to add multiple individual deploy keys for multiple private submodules
           # for a guide, see https://github.com/marketplace/actions/webfactory-ssh-agent
           ssh-private-key: |
             ${{ secrets.SSH_DEPLOY_KEY_CAMERA_SERVICE }}
-      - run: git submodule update --init --recursive
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -1,0 +1,102 @@
+# This workflow ensures the connected tests keep working
+#
+# @author Armin Schnabel
+# @version 1.0.0
+# @since 3.2.0
+name: Gradle Connected Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    # Faster, but MacOS costs 8 ct/min instead of 0.8 ct/min of on Linux.
+    # Unfortunately, `DataCapturingServiceTest.testDisconnectReconnect` fails on linux stack.
+    # But as this is a public repository, Github Actions are currently free of charge.
+    runs-on: macos-latest # as recommended in `actions/android-emulator-runner`
+
+    # To test against multiple APIs
+    strategy:
+      matrix:
+        api-level: [ 28 ]
+        target: [google_apis] # required as the app uses google maps
+
+    steps:
+      - uses: actions/checkout@v3
+        # Does not work out of the box with a private repository
+        # see https://github.com/actions/checkout/issues/287
+        #with:
+        #  submodules: true
+      - name: Add SSH private keys for submodule repositories
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          # This allows to add multiple individual deploy keys for multiple private submodules
+          # for a guide, see https://github.com/marketplace/actions/webfactory-ssh-agent
+          ssh-private-key: |
+            ${{ secrets.SSH_DEPLOY_KEY_CAMERA_SERVICE }}
+      - run: git submodule update --init --recursive
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Add gradle.properties
+        run: |
+          # Use a personal read token to install the Cyface Utils package
+          cp gradle.properties.template gradle.properties
+          echo "githubUser=${{ secrets.GH_READ_ACCOUNT }}" >> gradle.properties
+          echo "githubToken=${{ secrets.GH_READ_TOKEN }}" >> gradle.properties
+
+      - name: Inject dummy credentials for UI tests to skip login
+        run: |
+          # This mock API accepts all credentials and allows the UI test to skip the login
+          echo "cyface.staging_api=https://demo.cyface.de/api/v2" >> gradle.properties
+          echo "cyface.staging_user=guestLogin" >> gradle.properties
+          echo "cyface.staging_password=guestPassword" >> gradle.properties
+
+      # Not executing build here on MacOS stack (10x costs, if private repository)
+      # Not using "gradle build" as we don't want to run the tests of all dependencies (e.g. backend)
+      #- name: Assemble with Gradle
+      #  run: ./gradlew assemble
+      #- name: Test with Gradle
+      #  run: ./gradlew :measuring-client:test
+
+      # Add caching to speed up connected tests below (see `actions/android-emulator-runner`)
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          force-avd-creation: false
+          disable-animations: true
+          script: echo "Generated AVD snapshot for caching."
+
+      # Only execute mock tests to exclude `@FlakyTest`s (instead of running `connectedCheck`)
+      - name: Connected tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save
+          disable-animations: true
+          script: ./gradlew :measuring-client:connectedDebugAndroidTest
+          # To execute a single test class
+          #script: ./gradlew :measuring-client:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=de.cyface.app.CapturingNotificationTest

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -27,21 +27,24 @@ jobs:
         target: [google_apis] # required as the app uses google maps
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
         # Does not work out of the box with a private repository
         # see https://github.com/actions/checkout/issues/287
         #with:
         #  submodules: true
-      - name: Add SSH private keys for submodule repositories
+      - name: Link Deploy Keys for Submodules
         uses: webfactory/ssh-agent@v0.7.0
         with:
           # This allows to add multiple individual deploy keys for multiple private submodules
           # for a guide, see https://github.com/marketplace/actions/webfactory-ssh-agent
           ssh-private-key: |
             ${{ secrets.SSH_DEPLOY_KEY_CAMERA_SERVICE }}
-      - run: git submodule update --init --recursive
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
-      - uses: actions/setup-java@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -1,0 +1,104 @@
+# This workflow creates a signed Android Bundle which can be uploaded to Play Store Console
+#
+# @author Armin Schnabel
+# @version 1.0.0
+# @since 3.2.0
+name: Gradle Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        # Does not work out of the box with a private repository
+        # see https://github.com/actions/checkout/issues/287
+        #with:
+        #  submodules: true
+      - name: Link Deploy Keys for Submodules
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          # This allows to add multiple individual deploy keys for multiple private submodules
+          # for a guide, see https://github.com/marketplace/actions/webfactory-ssh-agent
+          ssh-private-key: |
+            ${{ secrets.SSH_DEPLOY_KEY_CAMERA_SERVICE }}
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Add sentry.properties
+        run: |
+          echo "defaults.project=android-app" > sentry.properties
+          echo "defaults.org=cyface" >> sentry.properties
+          echo "auth.token=${{ secrets.SENTRY_API_TOKEN }}" >> sentry.properties
+
+      - name: Add gradle.properties
+        run: |
+          # Use the repository's automatically set up token to publish to the registry
+          cp gradle.properties.template gradle.properties
+          echo "githubUser=${{ github.actor }}" >> gradle.properties
+          echo "githubToken=${{ secrets.GITHUB_TOKEN }}" >> gradle.properties
+          # Inject Cyface API URL
+          echo "cyface.api=${{ secrets.PUBLIC_API }}" >> gradle.properties
+          # Inject Google Maps API key
+          echo "google.maps_api_key=${{ secrets.GOOGLE_MAPS_KEY }}" >> gradle.properties
+
+      # As we previously published the app with version code up to 320, we need add this as offset
+      - name: Calculate versionCode
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          echo "VERSION_CODE=$((GITHUB_RUN_NUMBER + 320))" >> $GITHUB_ENV
+
+      # VersionCode and versionName are required to publish the app to Play Store
+      - name: Set versionCode and versionName
+        uses: chkfung/android-version-actions@v1.1
+        with:
+          gradlePath: measuring-client/build.gradle
+          versionCode: ${{ env.VERSION_CODE }}
+          versionName: ${{ github.ref_name }}
+
+      - name: Build App
+        run: ./gradlew bundleRelease
+
+      - name: Sign App
+        id: sign_app
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: measuring-client/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.SIGNING_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }} # optional
+
+      # We currently upload the app manually to Play Store, but we could automate this using a
+      # Google Service Account and the Github Action `r0adkll/upload-google-play`.
+      - name: Make app available
+        uses: actions/upload-artifact@v3
+        with:
+          name: Signed App Bundle
+          path: ${{ steps.sign_app.outputs.signedReleaseFile }}
+
+      # Automatically mark this tag as release on Github
+      - name: Mark tag as release on Github
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          # Release tags of format `1.2.3-beta1 / -alpha1 / -test1` are considered a pre-release
+          prerelease: ${{ contains(github.ref, 'test') || contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,7 @@
 
 image:https://github.com/cyface-de/android-app/actions/workflows/gradle_build.yml/badge.svg[link="https://github.com/cyface-de/android-app/actions/workflows/gradle_build.yml"]
 image:https://github.com/cyface-de/android-app/actions/workflows/gradle_connected-tests.yml/badge.svg[link="https://github.com/cyface-de/android-app/actions/workflows/gradle_connected-tests.yml"]
+image:https://github.com/cyface-de/android-app/actions/workflows/gradle_publish.yml/badge.svg[link="https://github.com/cyface-de/android-app/actions/workflows/gradle_publish.yml"]
 
 This project contains the Cyface Android Client.
 
@@ -125,11 +126,10 @@ $ git push
 
 See https://github.com/cyface-de/data-collector#release-a-new-version[Cyface Collector Readme]
 
-* Increase `versionName` in root `build.gradle`, `versionCode` is automatically incremented by the CI
-* Tag the release and push the branch and tag
-* After pushing the release tag to Github the Bitrise CI builds the Android Bundle automatically
-* Mark the release as release manually on Github, as we currently do only have Bitrise workflows
-* Checkout this build, copy the `measuring-client-release-bitrise-signed.aab` bundle from the artifacts and upload it to Play Store
+* `versionName` and `versionCode` in root `build.gradle` are automatically set by the CI
+* Just tag the release and push the branch and tag to Github
+* After pushing the release tag the CI builds and signs the App Bundle automatically
+* Checkout that build, copy the `measuring-client-release.aab` from the artifacts and upload it to Play Store
 
 
 [[license]]

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Cyface Android Client
 
-image:https://app.bitrise.io/app/c7da6c56a123928f/status.svg?token=RcVITFZtTSw7Yf5MjCQWvQ[Build Status,link="https://app.bitrise.io/app/c7da6c56a123928f"]
+image:https://github.com/cyface-de/android-app/actions/workflows/gradle_build.yml/badge.svg[link="https://github.com/cyface-de/android-app/actions/workflows/gradle_build.yml"]
+image:https://github.com/cyface-de/android-app/actions/workflows/gradle_connected-tests.yml/badge.svg[link="https://github.com/cyface-de/android-app/actions/workflows/gradle_connected-tests.yml"]
 
 This project contains the Cyface Android Client.
 
@@ -133,7 +134,7 @@ See https://github.com/cyface-de/data-collector#release-a-new-version[Cyface Col
 
 [[license]]
 == License
-Copyright 2017-2022 Cyface GmbH
+Copyright 2017-2023 Cyface GmbH
 
 This file is part of the Cyface App for Android.
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ buildscript {
 ext {
     // This app's version
     applicationId = "de.cyface.app"
-    versionName = "3.1.3" // Version shown to the user
+    versionName = "0.0.0" // Automatically overwritten by CI. Version shown to the user
     versionCode = 1 // Automatically incremented by CI. Required for Play Store releases
 
     /*

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -46,3 +46,5 @@ cyface.emulator_api=
 cyface.staging_api=
 cyface.staging_user=
 cyface.staging_password=
+
+# keep an empty line at the end for the CI to inject new lines easily

--- a/measuring-client/src/main/java/de/cyface/app/ui/Map.java
+++ b/measuring-client/src/main/java/de/cyface/app/ui/Map.java
@@ -151,7 +151,7 @@ public class Map implements OnMapReadyCallback, GoogleApiClient.ConnectionCallba
     }
 
     @Override
-    public void onMapReady(final GoogleMap googleMap) {
+    public void onMapReady(@NonNull final GoogleMap googleMap) {
         Validate.notNull(googleMap);
         this.googleMap = googleMap;
         googleMap.setMaxZoomPreference(2.0f);


### PR DESCRIPTION
This PR moves the CI workflows from Bitrise to Github Actions:
- the first commit moves the workflows which execute the tests
- the second commit re-implements the publish workflow which builds the Signed App Bundle, you can see that the bundle generation works [here](https://github.com/cyface-de/android-app/actions/runs/4183604770) at the bottom at `Artifacts`. Please ignore the Nodejs errors, this does not come from our code but from the Github Actions.
