### PR TITLE
[STAD-442] Try recommended emulator-options

### DIFF
--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -87,6 +87,7 @@ jobs:
       #  with:
       #    api-level: ${{ matrix.api-level }}
       #    target: ${{ matrix.target }}
+      #    profile: Pixel 2
       #    force-avd-creation: false
       ## the recommended options by the Actions did not work here?
       ## - emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -100,6 +101,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
+          profile: Pixel 2
           force-avd-creation: false
           # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           # Action recommendation: -no-snapshot-save -camera-back none

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -89,7 +89,6 @@ jobs:
       #  with:
       #    api-level: ${{ matrix.api-level }}
       #    target: ${{ matrix.target }}
-      ##    profile: Nexus 6 # doesn't seem to help stabilizing
       #    force-avd-creation: false
       ## the recommended options by the Actions did not work here?
       ## - emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -103,7 +102,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
-          #profile: Nexus 6 # doesn't seem to help stabilizing
           force-avd-creation: false
           # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           # Action recommendation: -no-snapshot-save -camera-back none

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -88,6 +88,9 @@ jobs:
       #    api-level: ${{ matrix.api-level }}
       #    target: ${{ matrix.target }}
       #    force-avd-creation: false
+      ## the recommended options by the Actions did not work here?
+      ## - emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+      ## Actions guide uses: `disable-animations: false` but this didn't work here?
       #    disable-animations: true
       #    script: echo "Generated AVD snapshot for caching."
 
@@ -99,9 +102,10 @@ jobs:
           target: ${{ matrix.target }}
           force-avd-creation: false
           # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
-          # Action recommendation: -no-snapshot-save
+          # Action recommendation: -no-snapshot-save -camera-back none
           # To support future camera capturing tests: -camera-back emulated
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim # -camera-back emulated
+          #   but this lead to `Timeout waiting for emulator` error
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./gradlew :measuring-client:connectedDebugAndroidTest
           # To execute a single test class

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 28 ]
-        target: [ default ] #[ google_apis ] # required as the app uses google maps
+        target: [ google_apis ] # required to avoid NPE in `Maps` at `GoogleMap.clear()`
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 28 ]
-        target: [google_apis] # required as the app uses google maps
+        target: [ default ] #[ google_apis ] # required as the app uses google maps
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -87,7 +87,7 @@ jobs:
       #  with:
       #    api-level: ${{ matrix.api-level }}
       #    target: ${{ matrix.target }}
-      #    profile: Pixel 2
+      ##    profile: Nexus 6 # doesn't seem to help stabilizing
       #    force-avd-creation: false
       ## the recommended options by the Actions did not work here?
       ## - emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -101,7 +101,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
-          profile: Nexus 6
+          #profile: Nexus 6 # doesn't seem to help stabilizing
           force-avd-creation: false
           # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           # Action recommendation: -no-snapshot-save -camera-back none

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -73,6 +73,7 @@ jobs:
       # Add caching to speed up connected tests below (see `actions/android-emulator-runner`)
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+
       #- name: AVD cache
       #  uses: actions/cache@v3
       #  id: avd-cache
@@ -80,7 +81,8 @@ jobs:
       #    path: |
       #      ~/.android/avd/*
       #      ~/.android/adb*
-      #    key: avd-${{ matrix.api-level }}
+      #    key: avd-${{ matrix.api-level }}-${{ matrix.target }} #-${{ matrix.arch }}
+
       #- name: Create AVD and generate snapshot for caching
       #  if: steps.avd-cache.outputs.cache-hit != 'true'
       #  uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -98,7 +98,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./gradlew :measuring-client:connectedDebugAndroidTest
           # To execute a single test class

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -98,7 +98,10 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          # Action recommendation: -no-snapshot-save
+          # To support future camera capturing tests: -camera-back emulated
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim # -camera-back emulated
           disable-animations: true
           script: ./gradlew :measuring-client:connectedDebugAndroidTest
           # To execute a single test class

--- a/.github/workflows/gradle_connected-tests.yml
+++ b/.github/workflows/gradle_connected-tests.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
-          profile: Pixel 2
+          profile: Nexus 6
           force-avd-creation: false
           # default options are: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           # Action recommendation: -no-snapshot-save -camera-back none

--- a/README.adoc
+++ b/README.adoc
@@ -133,6 +133,21 @@ See https://github.com/cyface-de/data-collector#release-a-new-version[Cyface Col
 * The tag is automatically marked as a 'new Release' on https://github.com/cyface-de/android-app/releases[Github]
 
 
+[[known-issues]]]
+== Known Issues
+The CI tests are flaky, due to emulator-flakiness on the CIs we tried (Bitrise, Github Actions).
+- examples for this, see e.g. https://github.com/leancodepl/patrol/issues/765
+- or https://github.com/ReactiveCircus/android-emulator-runner/issues/192
+- we could add auto-repeat to the CI workflow, but this is only a workaround
+- see https://github.com/ankidroid/Anki-Android/pull/11032/files?diff=split&w=0
+
+The AVD Cache leads to `Install_failed_Update_Incompatible` after a few builds.
+- we opened an issue here: https://github.com/ReactiveCircus/android-emulator-runner/issues/319
+- we could try to make the AVD cache only be used on main branch like
+- see https://github.com/ankidroid/Anki-Android/pull/11032/files?diff=split&w=0
+- but for now, we just disabled the AVD cache for the CI to be usable
+
+
 [[license]]
 == License
 Copyright 2017-2023 Cyface GmbH

--- a/README.adoc
+++ b/README.adoc
@@ -135,17 +135,18 @@ See https://github.com/cyface-de/data-collector#release-a-new-version[Cyface Col
 
 [[known-issues]]]
 == Known Issues
-The CI tests are flaky, due to emulator-flakiness on the CIs we tried (Bitrise, Github Actions).
-- examples for this, see e.g. https://github.com/leancodepl/patrol/issues/765
-- or https://github.com/ReactiveCircus/android-emulator-runner/issues/192
-- we could add auto-repeat to the CI workflow, but this is only a workaround
-- see https://github.com/ankidroid/Anki-Android/pull/11032/files?diff=split&w=0
 
 The AVD Cache leads to `Install_failed_Update_Incompatible` after a few builds.
 - we opened an issue here: https://github.com/ReactiveCircus/android-emulator-runner/issues/319
 - we could try to make the AVD cache only be used on main branch like
 - see https://github.com/ankidroid/Anki-Android/pull/11032/files?diff=split&w=0
 - but for now, we just disabled the AVD cache for the CI to be usable
+
+If the CI tests become flaky due to emulator-instability on the CI:
+- examples for this, see e.g. https://github.com/leancodepl/patrol/issues/765
+- or https://github.com/ReactiveCircus/android-emulator-runner/issues/192
+- we could add auto-repeat to the CI workflow, but this is only a workaround
+- see https://github.com/ankidroid/Anki-Android/pull/11032/files?diff=split&w=0
 
 
 [[license]]


### PR DESCRIPTION
1+3 CI builds in [Gradle Connected Tests](https://github.com/cyface-de/android-app/actions/workflows/gradle_connected-tests.yml) were successful with this specific configuration, so we merge this to `main`.