### PR TITLE
Enable logout funktionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     cyfaceUploaderVersion = "1.3.0"
     // These versions just document the currently linked version of this dependency.
     // To upgrade the dependencies you need to update the submodules to a newer commit.
-    cyfaceAndroidBackendVersion = "7.11.1" // FIXME
+    cyfaceAndroidBackendVersion = "7.11.2"
     cyfaceEnergySettingsVersion = "4.0.6"
     cyfaceCameraServiceVersion = "4.5.7"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Cyface GmbH
+ * Copyright 2017-2024 Cyface GmbH
  *
  * This file is part of the Cyface App for Android.
  *
@@ -21,8 +21,6 @@
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.6.0
- * @since 1.0.0
  */
 
 buildscript {
@@ -68,7 +66,7 @@ ext {
     cyfaceUploaderVersion = "1.3.0"
     // These versions just document the currently linked version of this dependency.
     // To upgrade the dependencies you need to update the submodules to a newer commit.
-    cyfaceAndroidBackendVersion = "7.11.1"
+    cyfaceAndroidBackendVersion = "7.11.1" // FIXME
     cyfaceEnergySettingsVersion = "4.0.6"
     cyfaceCameraServiceVersion = "4.5.7"
 

--- a/ui/cyface/src/main/kotlin/de/cyface/app/MainActivity.kt
+++ b/ui/cyface/src/main/kotlin/de/cyface/app/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Cyface GmbH
+ * Copyright 2017-2024 Cyface GmbH
  *
  * This file is part of the Cyface App for Android.
  *
@@ -91,8 +91,6 @@ import java.lang.ref.WeakReference
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.2.0
- * @since 1.0.0
  */
 class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider {
 
@@ -201,7 +199,7 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
         }
 
         // Authorization
-        auth = OAuth2(applicationContext, CyfaceAuthenticator.settings)
+        auth = OAuth2(applicationContext, CyfaceAuthenticator.settings, "MainActivity")
 
         /****************************************************************************************/
         // Crashes with RuntimeException: `capturing`/`auth` not initialized when this is above

--- a/ui/cyface/src/main/kotlin/de/cyface/app/MainActivity.kt
+++ b/ui/cyface/src/main/kotlin/de/cyface/app/MainActivity.kt
@@ -24,6 +24,9 @@ import android.accounts.AccountManagerFuture
 import android.accounts.AuthenticatorException
 import android.accounts.OperationCanceledException
 import android.app.Activity
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
@@ -79,6 +82,7 @@ import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.TokenResponse
 import java.io.IOException
 import java.lang.ref.WeakReference
+import kotlin.system.exitProcess
 
 
 /**
@@ -268,10 +272,21 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
         super.onActivityResult(requestCode, resultCode, data)
 
         // Authorization
-        if (requestCode == END_SESSION_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            Handler().postDelayed({ signOut(true); finish() }, 2000)
-        } else {
-            show("Sign out canceled")
+        if (requestCode == END_SESSION_REQUEST_CODE) {
+            if (resultCode == Activity.RESULT_OK) {
+                Handler().postDelayed({
+                    // [LEIP-233] There is an open bug which leads to `Credentials incorrect` error
+                    // after re-login (app restart required). We tried, without success:
+                    // - stopBackgroundServices() w/DCBGService, CyfaceSyncService and AuthService
+                    // - cacheDir.deleteRecursively()
+                    // - restartApp() in `signOut()`
+                    // We don't need to cancel pending jobs are we don't use the job scheduler.
+                    signOut(true)
+                }, 2000)
+            } else {
+                show(getString(de.cyface.app.utils.R.string.message_logout_aborted_or_failed))
+                Log.e("MainActivity", "Sign out canceled or failed")
+            }
         }
     }
 
@@ -442,14 +457,35 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
         // E.g. `MainActivity.onStart()` calls `signOut()` when the user is already signed out
         // so there is no account to be removed.
         if (removeAccount) {
-            // Also remove account from account manager
             capturing.removeAccount(capturing.wiFiSurveyor.account.name)
         }
 
+        // Ensure the login screen is shown after logout
         val mainIntent = Intent(this, LoginActivity::class.java)
-        mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(mainIntent)
-        finish()
+
+        // Restarting the app after the account is removed help to fix a bug where the app crashes
+        // when switching to the `trips` tab after re-login (with incentives active)
+        if (removeAccount) {
+            // [LEIP-233] restarting the app completely does not fix the `Credentials incorrect` error
+            // after re-login, a manual app restart is still required after re-login.
+            restartApp(this)
+        } else {
+            // With `restartApp()`: when aborting login the app restarts every 2s
+            finish()
+        }
+    }
+
+    private fun restartApp(context: Context) {
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 100, pendingIntent)
+        exitProcess(0)
     }
 
     @MainThread

--- a/ui/cyface/src/main/kotlin/de/cyface/app/capturing/MenuProvider.kt
+++ b/ui/cyface/src/main/kotlin/de/cyface/app/capturing/MenuProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Cyface GmbH
+ * Copyright 2023-2024 Cyface GmbH
  *
  * This file is part of the Cyface App for Android.
  *
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import de.cyface.app.CapturingFragmentDirections
@@ -29,14 +30,13 @@ import de.cyface.app.MainActivity
 import de.cyface.app.R
 import de.cyface.app.utils.Constants.SUPPORT_EMAIL
 import de.cyface.energy_settings.TrackingSettings
+import de.cyface.uploader.exception.SynchronisationException
 
 /**
  * The [androidx.core.view.MenuProvider] for the [de.cyface.app.CapturingFragment] which defines which
  * options are shown in the action bar at the top right.
  *
  * @author Armin Schnabel
- * @version 2.0.1
- * @since 3.2.0
  */
 class MenuProvider(
     private val activity: MainActivity,
@@ -98,21 +98,25 @@ class MenuProvider(
                 navController.navigate(action)
                 true
             }
-            /*R.id.logout_item -> {
+
+            R.id.logout_item -> {
                 try {
                     Toast.makeText(activity.applicationContext, "Logging out ...", Toast.LENGTH_SHORT).show()
+
                     // This inform the auth server that the user wants to end its session
                     activity.auth.endSession(activity)
-                    //signOut() // instead of `endSession()` to sign out softly for testing
-                    activity.capturing.removeAccount(activity.capturing.wiFiSurveyor.account.name)
+                    //signOut() // use instead of `endSession()` to sign out softly for testing
+
+                    // The account is removed in `MainActivity.signOut()` instead of here
                 } catch (e: SynchronisationException) {
                     throw IllegalStateException(e)
                 }
                 // Show login screen
-                // This is done by MainActivity.onActivityResult -> signOut()
+                // We currently start the `LoginActivity` explicitly in `MainActivity.signOut()`
                 //(activity as MainActivity).startSynchronization()
                 true
-            }*/
+            }
+
             else -> {
                 false
             }

--- a/ui/cyface/src/main/res/menu/capturing.xml
+++ b/ui/cyface/src/main/res/menu/capturing.xml
@@ -21,10 +21,9 @@
     android:icon="@drawable/ic_business"
     android:title="@string/drawer_title_imprint"
     app:showAsAction="never" />
-  <!-- Disabled as this breaks upload (unauthorized) after login [RFR-564]
-  item
-    android:id="@+id/logout_item"
-    android:icon="@drawable/ic_logout"
-    android:title="@string/drawer_title_logout"
-    app:showAsAction="never" /-->
+  <item
+      android:id="@+id/logout_item"
+      android:icon="@drawable/ic_logout"
+      android:title="@string/drawer_title_logout"
+      app:showAsAction="never" />
 </menu>

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/MainActivity.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/MainActivity.kt
@@ -26,21 +26,16 @@ import android.accounts.OperationCanceledException
 import android.app.Activity
 import android.app.AlarmManager
 import android.app.PendingIntent
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.Handler
-import android.os.IBinder
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -59,24 +54,23 @@ import de.cyface.app.utils.ServiceProvider
 import de.cyface.app.utils.capturing.settings.UiSettings
 import de.cyface.datacapturing.CyfaceDataCapturingService
 import de.cyface.datacapturing.DataCapturingListener
-import de.cyface.persistence.SetupException
 import de.cyface.datacapturing.model.CapturedData
 import de.cyface.datacapturing.ui.Reason
 import de.cyface.energy_settings.TrackingSettings.showEnergySaferWarningDialog
 import de.cyface.energy_settings.TrackingSettings.showGnssWarningDialog
 import de.cyface.energy_settings.TrackingSettings.showProblematicManufacturerDialog
 import de.cyface.energy_settings.TrackingSettings.showRestrictedBackgroundProcessingWarningDialog
+import de.cyface.persistence.SetupException
 import de.cyface.persistence.model.ParcelableGeoLocation
 import de.cyface.synchronization.CyfaceAuthenticator
-import de.cyface.synchronization.CyfaceAuthenticatorService
 import de.cyface.synchronization.CyfaceSyncService.Companion.AUTH_TOKEN_TYPE
 import de.cyface.synchronization.OAuth2
 import de.cyface.synchronization.OAuth2.Companion.END_SESSION_REQUEST_CODE
 import de.cyface.synchronization.WiFiSurveyor
 import de.cyface.uploader.exception.SynchronisationException
-import de.cyface.utils.settings.AppSettings
 import de.cyface.utils.DiskConsumption
 import de.cyface.utils.Validate
+import de.cyface.utils.settings.AppSettings
 import io.sentry.Sentry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -265,38 +259,20 @@ class MainActivity : AppCompatActivity(), ServiceProvider {
         if (requestCode == END_SESSION_REQUEST_CODE) {
             if (resultCode == Activity.RESULT_OK) {
                 Handler().postDelayed({
-                    // upload after re-login not working, have to restart the app manually
-                    //stopBackgroundServices()
-                    //cancelPendingJobs() we don't use the job scheduler at the moment
-                    //restartApp()
-                    cacheDir.deleteRecursively()
+                    // [LEIP-233] There is an open bug which leads to `Credentials incorrect` error
+                    // after re-login (app restart required). We tried, without success:
+                    // - stopBackgroundServices() w/DCBGService, CyfaceSyncService and AuthService
+                    // - cacheDir.deleteRecursively()
+                    // - restartApp() in `signOut()`
+                    // We don't need to cancel pending jobs are we don't use the job scheduler.
                     signOut(true)
-                    //finish()
                 }, 2000)
             } else {
-                show("Logout abgebrochen oder fehlgeschlagen") // FIXME
+                show(getString(de.cyface.app.utils.R.string.message_logout_aborted_or_failed))
                 Log.e("MainActivity", "Sign out canceled or failed")
             }
         }
     }
-
-    /*private fun stopBackgroundServices() {
-        // Ensure no background processes survive which try to use the old auth state
-        /*val intent1 = Intent(this, DataCapturingBackgroundService::class.java)
-        stopService(intent1)*/
-        val intent2 = Intent(this, CyfaceSyncService::class.java)
-        stopService(intent2)
-        /*val intent3 = Intent(this, AuthorizationService::class.java)
-        stopService(intent3)*/
-    }*/
-
-    /*private fun restartApp() {
-        val intent = packageManager.getLaunchIntentForPackage(packageName)
-        intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(intent)
-        finish()
-        Runtime.getRuntime().exit(0)
-    }*/
 
     /**
      * Fixes "home" (back) button in the top action bar when in the fragment details fragment.
@@ -372,7 +348,8 @@ class MainActivity : AppCompatActivity(), ServiceProvider {
                     Validate.notNull(account)
 
                     // Set synchronizationEnabled to the current user preferences
-                    val syncEnabledPreference = runBlocking { appSettings.uploadEnabledFlow.first() }
+                    val syncEnabledPreference =
+                        runBlocking { appSettings.uploadEnabledFlow.first() }
                     Log.d(
                         WiFiSurveyor.TAG,
                         "Setting syncEnabled for new account to preference: $syncEnabledPreference"
@@ -476,29 +453,32 @@ class MainActivity : AppCompatActivity(), ServiceProvider {
         // E.g. `MainActivity.onStart()` calls `signOut()` when the user is already signed out
         // so there is no account to be removed.
         if (removeAccount) {
-            // Also remove account from account manager
-            //if (account != null) {
             capturing.removeAccount(capturing.wiFiSurveyor.account.name)
-            //} else {
-            //    Log.w(TAG, "No account found to be removed.") // FIXME: why does this happen?
-            //}
-            val mainIntent = Intent(this, LoginActivity::class.java)
-            mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-            startActivity(mainIntent)
+        }
+
+        // Ensure the login screen is shown after logout
+        val mainIntent = Intent(this, LoginActivity::class.java)
+        mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(mainIntent)
+
+        // Restarting the app after the account is removed help to fix a bug where the app crashes
+        // when switching to the `trips` tab after re-login (with incentives active)
+        if (removeAccount) {
+            // [LEIP-233] restarting the app completely does not fix the `Credentials incorrect` error
+            // after re-login, a manual app restart is still required after re-login.
             restartApp(this)
         } else {
-            val mainIntent = Intent(this, LoginActivity::class.java)
-            mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-            startActivity(mainIntent)
-            //restartApp(this)
+            // With `restartApp()`: when aborting login the app restarts every 2s
             finish()
         }
     }
 
     private fun restartApp(context: Context) {
         val intent = Intent(context, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(context, 0, intent,
-            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 100, pendingIntent)
         exitProcess(0)

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Cyface GmbH
+ * Copyright 2023-2024 Cyface GmbH
  *
  * This file is part of the Cyface App for Android.
  *
@@ -94,8 +94,6 @@ import java.util.concurrent.TimeUnit
  * The [ViewModel]s are responsible for holding the `LiveData` data.
  *
  * @author Armin Schnabel
- * @version 1.0.1
- * @since 3.2.0
  */
 class CapturingFragment : Fragment(), DataCapturingListener {
 

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Cyface GmbH
+ * Copyright 2023 Cyface GmbH
  *
  * This file is part of the Cyface App for Android.
  *
@@ -94,6 +94,8 @@ import java.util.concurrent.TimeUnit
  * The [ViewModel]s are responsible for holding the `LiveData` data.
  *
  * @author Armin Schnabel
+ * @version 1.0.1
+ * @since 3.2.0
  */
 class CapturingFragment : Fragment(), DataCapturingListener {
 

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/MenuProvider.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/MenuProvider.kt
@@ -105,18 +105,16 @@ class MenuProvider(
                 try {
                     Toast.makeText(activity.applicationContext, "Logging out ...", Toast.LENGTH_SHORT).show()
 
-                    stopBackgroundServices()
                     // This inform the auth server that the user wants to end its session
                     activity.auth.endSession(activity)
-                    //signOut() // instead of `endSession()` to sign out softly for testing
+                    //signOut() // use instead of `endSession()` to sign out softly for testing
 
-                    // FIXME: Disabled as this can also be done by the callback
-                    //activity.capturing.removeAccount(activity.capturing.wiFiSurveyor.accountOrNull.name)
+                    // THe account is removed in `MainActivity.signOut()` instead of here
                 } catch (e: SynchronisationException) {
                     throw IllegalStateException(e)
                 }
                 // Show login screen
-                // This is done by MainActivity.onActivityResult -> signOut()
+                // We currently start the `LoginActivity` explicitly in `MainActivity.signOut()`
                 //(activity as MainActivity).startSynchronization()
                 true
             }
@@ -125,14 +123,5 @@ class MenuProvider(
                 false
             }
         }
-    }
-    private fun stopBackgroundServices() {
-        // Ensure no background processes survive which try to use the old auth state
-        val intent1 = Intent(activity, DataCapturingBackgroundService::class.java)
-        activity.stopService(intent1)
-        val intent2 = Intent(activity, CyfaceSyncService::class.java)
-        activity.stopService(intent2)
-        val intent3 = Intent(activity, AuthorizationService::class.java)
-        activity.stopService(intent3)
     }
 }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/MenuProvider.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/MenuProvider.kt
@@ -109,7 +109,7 @@ class MenuProvider(
                     activity.auth.endSession(activity)
                     //signOut() // use instead of `endSession()` to sign out softly for testing
 
-                    // THe account is removed in `MainActivity.signOut()` instead of here
+                    // The account is removed in `MainActivity.signOut()` instead of here
                 } catch (e: SynchronisationException) {
                     throw IllegalStateException(e)
                 }

--- a/ui/r4r/src/main/res/menu/capturing.xml
+++ b/ui/r4r/src/main/res/menu/capturing.xml
@@ -21,7 +21,6 @@
     android:icon="@drawable/ic_business"
     android:title="@string/drawer_title_imprint"
     app:showAsAction="never" />
-  <!-- FIXME: Disabled as this breaks upload (unauthorized) after login [RFR-564] -->
   <item
     android:id="@+id/logout_item"
     android:icon="@drawable/ic_logout"

--- a/ui/r4r/src/main/res/menu/capturing.xml
+++ b/ui/r4r/src/main/res/menu/capturing.xml
@@ -21,10 +21,10 @@
     android:icon="@drawable/ic_business"
     android:title="@string/drawer_title_imprint"
     app:showAsAction="never" />
-  <!-- Disabled as this breaks upload (unauthorized) after login [RFR-564]
-  item
+  <!-- FIXME: Disabled as this breaks upload (unauthorized) after login [RFR-564] -->
+  <item
     android:id="@+id/logout_item"
     android:icon="@drawable/ic_logout"
     android:title="@string/drawer_title_logout"
-    app:showAsAction="never" /-->
+    app:showAsAction="never" />
 </menu>

--- a/utils/src/main/kotlin/de/cyface/app/utils/trips/TripsFragment.kt
+++ b/utils/src/main/kotlin/de/cyface/app/utils/trips/TripsFragment.kt
@@ -543,8 +543,10 @@ class TripsFragment : Fragment() {
                                     }
                                 } else {
                                     showNoVouchersLeft()
-                                    _binding?.achievementsError?.visibility = GONE
-                                    _binding?.achievements?.visibility = GONE
+                                    /*Handler(Looper.getMainLooper()).post {
+                                        _binding?.achievementsError?.visibility = GONE
+                                        _binding?.achievements?.visibility = GONE
+                                    }*/
                                 }
                             } catch (e: JSONException) {
                                 handleJsonException(e)

--- a/utils/src/main/kotlin/de/cyface/app/utils/trips/TripsFragment.kt
+++ b/utils/src/main/kotlin/de/cyface/app/utils/trips/TripsFragment.kt
@@ -543,10 +543,6 @@ class TripsFragment : Fragment() {
                                     }
                                 } else {
                                     showNoVouchersLeft()
-                                    /*Handler(Looper.getMainLooper()).post {
-                                        _binding?.achievementsError?.visibility = GONE
-                                        _binding?.achievements?.visibility = GONE
-                                    }*/
                                 }
                             } catch (e: JSONException) {
                                 handleJsonException(e)

--- a/utils/src/main/res/values-de/strings.xml
+++ b/utils/src/main/res/values-de/strings.xml
@@ -34,6 +34,7 @@
     <string name="authorization_canceled">Anmeldung abgebrochen</string>
     <string name="logging_in">Sie werden eingeloggt …</string>
     <string name="retry">Erneut versuchen</string>
+    <string name="message_logout_aborted_or_failed">Logout abgebrochen oder fehlgeschlagen</string>
 
     <!-- BottomNavigationView, also used as Toolbar / AppBar title -->
     <string name="trips">Fahrten</string>

--- a/utils/src/main/res/values/strings.xml
+++ b/utils/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="authorization_canceled">Login aborted</string>
     <string name="logging_in">Logging in …</string>
     <string name="retry">Try again</string>
+    <string name="message_logout_aborted_or_failed">Logout aborted or failed</string>
 
     <!-- BottomNavigationView -->
     <string name="trips">Trips</string>


### PR DESCRIPTION
This PR re-enables the logout in the Cyface and RFR UI.

**Attention: There is still a bug in the logout which leads to a `Credentials incorrect`  error after logging in with another account. You need to restart the app to fix this. But this is still better than no logout functionality.**