### PR TITLE
Remove camera dependency from RFR UI for public release

### DIFF
--- a/ui/r4r/build.gradle
+++ b/ui/r4r/build.gradle
@@ -235,7 +235,9 @@ dependencies {
     implementation project(':synchronization')
     implementation project(':persistence')
     implementation project(':energy_settings')
-    implementation project(':camera_service')
+    // disabled for public release or else we have to explain in play store what this is used for
+    // we currently only use camera it internally.
+    // implementation project(':camera_service')
     implementation project(':utils')
 
     // Dependencies for instrumentation tests

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/CameraServiceProvider.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/CameraServiceProvider.kt
@@ -18,8 +18,8 @@
  */
 package de.cyface.app.r4r
 
-import de.cyface.camera_service.settings.CameraSettings
-import de.cyface.camera_service.foreground.CameraService
+//import de.cyface.camera_service.settings.CameraSettings
+//import de.cyface.camera_service.foreground.CameraService
 
 /**
  * Interface which defines the dependencies implemented by the `MainActivity` to be accessible from
@@ -28,6 +28,6 @@ import de.cyface.camera_service.foreground.CameraService
  * @author Armin Schnabel
  */
 interface CameraServiceProvider {
-    val cameraService: CameraService
-    val cameraSettings: CameraSettings
+    //val cameraService: CameraService
+    //val cameraSettings: CameraSettings
 }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/MainActivity.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/MainActivity.kt
@@ -44,9 +44,9 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import de.cyface.app.r4r.auth.LoginActivity
-import de.cyface.app.r4r.capturing.UnInterestedListener
+//import de.cyface.app.r4r.capturing.UnInterestedListener
 import de.cyface.app.r4r.databinding.ActivityMainBinding
-import de.cyface.app.r4r.notification.CameraEventHandler
+//import de.cyface.app.r4r.notification.CameraEventHandler
 import de.cyface.app.r4r.notification.CapturingEventHandler
 import de.cyface.app.r4r.utils.Constants.ACCOUNT_TYPE
 import de.cyface.app.r4r.utils.Constants.AUTHORITY
@@ -55,9 +55,6 @@ import de.cyface.app.r4r.utils.Constants.TAG
 import de.cyface.app.utils.ServiceProvider
 import de.cyface.app.utils.capturing.settings.UiConfig
 import de.cyface.app.utils.capturing.settings.UiSettings
-import de.cyface.camera_service.background.camera.CameraListener
-import de.cyface.camera_service.foreground.CameraService
-import de.cyface.camera_service.settings.CameraSettings
 import de.cyface.datacapturing.CyfaceDataCapturingService
 import de.cyface.datacapturing.DataCapturingListener
 import de.cyface.datacapturing.model.CapturedData
@@ -101,7 +98,7 @@ import kotlin.system.exitProcess
  * @version 5.0.0
  * @since 1.0.0
  */
-class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider {
+class MainActivity : AppCompatActivity(), ServiceProvider/*, CameraServiceProvider*/ {
 
     /**
      * The generated class which holds all bindings from the layout file.
@@ -116,7 +113,7 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
     /**
      * The `CameraService` which collects camera data if the user did activate this feature.
      */
-    override lateinit var cameraService: CameraService
+    // override lateinit var cameraService: CameraService
 
     /**
      * The controller which allows to navigate through the navigation graph.
@@ -137,7 +134,7 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
     /**
      * The settings used to store the user preferences for the camera.
      */
-    override lateinit var cameraSettings: CameraSettings
+    // override lateinit var cameraSettings: CameraSettings
 
     /**
      * The authorization.
@@ -165,7 +162,7 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
         override fun onCapturingStopped() = Unit
     }
 
-    private val unInterestedCameraListener: CameraListener = object :
+    /*private val unInterestedCameraListener: CameraListener = object :
         CameraListener {
         override fun onNewPictureAcquired(picturesCaptured: Int) = Unit
         override fun onNewVideoStarted() = Unit
@@ -177,11 +174,11 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
         }
 
         override fun onCameraCapturingStopped() = Unit
-    }
+    }*/
 
     override fun onCreate(savedInstanceState: Bundle?) {
         uiSettings = UiSettings.getInstance(this, UiConfig(BuildConfig.incentivesServer))
-        cameraSettings = CameraSettings.getInstance(this)
+        // cameraSettings = CameraSettings.getInstance(this)
 
         // Start DataCapturingService and CameraService
         // With async call the app crashes as late-init `capturing` is not initialized yet.
@@ -201,12 +198,12 @@ class MainActivity : AppCompatActivity(), ServiceProvider, CameraServiceProvider
             // a specific exception when the LOGIN_ACTIVITY was not set from the SDK using app.
             //startSynchronization() // We do this in displayAuthorized() instead!
             // We don't have a sync progress button: `capturingService.addConnectionStatusListener(this)`
-            cameraService = CameraService(
+            /*cameraService = CameraService(
                 applicationContext,
                 CameraEventHandler(),
                 unInterestedCameraListener, // here was the capturing button but it registers itself, too
                 UnInterestedListener()
-            )
+            )*/
         } catch (e: SetupException) {
             throw IllegalStateException(e)
         }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/CapturingFragment.kt
@@ -50,7 +50,6 @@ import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
-import de.cyface.app.r4r.CameraServiceProvider
 import de.cyface.app.r4r.MainActivity
 import de.cyface.app.r4r.R
 import de.cyface.app.r4r.capturing.map.MapFragment
@@ -61,13 +60,13 @@ import de.cyface.app.r4r.utils.Constants
 import de.cyface.app.r4r.utils.Constants.TAG
 import de.cyface.app.utils.CalibrationDialogListener
 import de.cyface.app.utils.ServiceProvider
-import de.cyface.camera_service.CameraInfo
+/*import de.cyface.camera_service.CameraInfo
 import de.cyface.camera_service.UIListener
 import de.cyface.camera_service.background.TriggerMode
 import de.cyface.camera_service.background.camera.CameraListener
 import de.cyface.camera_service.foreground.CameraService
 import de.cyface.camera_service.settings.CameraSettings
-import de.cyface.camera_service.settings.OriginalDigural
+import de.cyface.camera_service.settings.OriginalDigural*/
 import de.cyface.datacapturing.CyfaceDataCapturingService
 import de.cyface.datacapturing.DataCapturingListener
 import de.cyface.datacapturing.DataCapturingService
@@ -113,7 +112,7 @@ import java.util.concurrent.TimeUnit
  * @version 2.0.0
  * @since 1.0.0
  */
-class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
+class CapturingFragment : Fragment(), DataCapturingListener/*, CameraListener*/ {
 
     /**
      * This property is only valid between onCreateView and onDestroyView.
@@ -133,7 +132,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
     /**
      * The [CameraService] required to control and check the visual capturing process.
      */
-    private lateinit var cameraService: CameraService
+    //private lateinit var cameraService: CameraService
 
     /**
      * The settings used by both, UIs and libraries.
@@ -143,7 +142,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
     /**
      * The settings used by the camera service.
      */
-    private lateinit var cameraSettings: CameraSettings
+    //private lateinit var cameraSettings: CameraSettings
 
     /**
      * An implementation of the persistence layer which caches some data during capturing.
@@ -208,12 +207,12 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         } else {
             error("Context doesn't support the Fragment, implement `ServiceProvider`")
         }
-        if (activity is CameraServiceProvider) {
+        /*if (activity is CameraServiceProvider) {
             cameraService = (activity as CameraServiceProvider).cameraService
             cameraSettings = (activity as CameraServiceProvider).cameraSettings
         } else {
             error("Context doesn't support the Fragment, implement `CameraServiceProvider`")
-        }
+        }*/
     }
 
     /**
@@ -447,9 +446,9 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         // Nothing to do here - handled by [CapturingEventHandler]
     }
 
-    override fun onCameraLowDiskSpace(allocation: DiskConsumption) {
+    /*override fun onCameraLowDiskSpace(allocation: DiskConsumption) {
         // Nothing to do here - handled by [CapturingEventHandler]
-    }
+    }*/
 
     override fun onSynchronizationSuccessful() {
         // Nothing to do here
@@ -459,9 +458,9 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         throw java.lang.IllegalStateException(e)
     }
 
-    override fun onCameraErrorState(e: Exception) {
+    /*override fun onCameraErrorState(e: Exception) {
         throw java.lang.IllegalStateException(e)
-    }
+    }*/
 
     override fun onRequiresPermission(
         permission: String,
@@ -470,9 +469,9 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         return false
     }
 
-    override fun onCameraRequiresPermission(permission: String, reason: Reason): Boolean {
+    /*override fun onCameraRequiresPermission(permission: String, reason: Reason): Boolean {
         return false
-    }
+    }*/
 
     override fun onCapturingStopped() {
         // Between roughly SDK 6.4.2 and 7.12.11 we used local broadcasts, which broke the
@@ -484,20 +483,20 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         // ShutdownFinishedHandler, as this would "hide" a broken handler without intention.
 
         Log.d(TAG, "onCapturingStopped")
-        checkAndStopCameraCapturing(capturingStopped = true, updateUi = true, pause = false)
+        //checkAndStopCameraCapturing(capturingStopped = true, updateUi = true, pause = false)
     }
 
-    override fun onCameraCapturingStopped() {
+    /*override fun onCameraCapturingStopped() {
         Log.d(TAG, "onCameraCapturingStopped")
         checkAndStopCapturing(crashAsyncUI = false, pause = false)
-    }
+    }*/
 
     /**
      * Checks the current capturing state and refreshes the UI elements accordingly.
      */
     private suspend fun reconnect() {
         capturing.addDataCapturingListener(this)
-        cameraService.addCameraListener(this)
+        //cameraService.addCameraListener(this)
 
         // To avoid blocking the UI when switching Tabs, this is implemented in an async way.
         // I.e. we disable all buttons as the capturingState is set in the callback.
@@ -517,13 +516,13 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
             updateCachedTrack(id)
 
             // Also try to reconnect to CameraService if it's alive
-            if (cameraService.reconnect(DataCapturingService.IS_RUNNING_CALLBACK_TIMEOUT)) {
+            /*if (cameraService.reconnect(DataCapturingService.IS_RUNNING_CALLBACK_TIMEOUT)) {
                 // It does not matter whether isCameraServiceRequested() as this can change all the time
                 Log.d(
                     TAG,
                     "onResume: reconnecting CameraService succeeded"
                 )
-            }
+            }*/
             return
         }
 
@@ -540,7 +539,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         // Check if there is a zombie CameraService running
         // In case anything went wrong and the camera is still bound by this app we're releasing it so that it
         // can be used by other apps again
-        if (cameraService.reconnect(DataCapturingService.IS_RUNNING_CALLBACK_TIMEOUT)) {
+        /*if (cameraService.reconnect(DataCapturingService.IS_RUNNING_CALLBACK_TIMEOUT)) {
             Log.w(
                 TAG,
                 "Zombie CameraService is running and it's "
@@ -557,7 +556,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                 })
             // TODO: This cancels the stop above, we need a onTimedOut [LEIP-327]
             error("Camera stopped manually as the camera was not released. This should not happen!")
-        }
+        }*/
     }
 
     /**
@@ -565,7 +564,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
      */
     private fun disconnect() {
         capturing.removeDataCapturingListener(this)
-        cameraService.removeCameraListener(this)
+        //cameraService.removeCameraListener(this)
 
         try {
             capturing.disconnect()
@@ -573,12 +572,12 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
             // This just tells us there is no running capturing in the background, see [MOV-588]
             Log.d(TAG, "No need to unbind as the background service was not running.")
         }
-        try {
+        /*try {
             cameraService.disconnect()
         } catch (e: DataCapturingException) {
             // This just tells us there is no running capturing in the background, see [MOV-588]
             Log.d(TAG, "No need to unbind as the camera background service was not running.")
-        }
+        }*/
 
         viewModel.setMeasurementId(null) // Experimental, might influence other Fragments
         //setCapturingStatus(null) // Seems not necessary right not, but is called in `reconnect`
@@ -650,7 +649,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                     // Ensures both services stopped to avoid btn out of sync [LEIP-299]
                     val target = if (pause) "pause" else "stop"
                     Log.d(TAG, "stopCapturing: $target finished")
-                    checkAndStopCameraCapturing(capturingStopped = true, updateUi = true, pause)
+                    //checkAndStopCameraCapturing(capturingStopped = true, updateUi = true, pause)
                 }
             }
             if (pause) {
@@ -702,7 +701,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
 
                         // Start CameraService
                         lifecycleScope.launch {
-                            if (withContext(Dispatchers.IO) { cameraSettings.cameraEnabledFlow.first() }) {
+                            /*if (withContext(Dispatchers.IO) { cameraSettings.cameraEnabledFlow.first() }) {
                                 Log.d(TAG, "CameraServiceRequested")
                                 try {
                                     startCameraService(measurementIdentifier)
@@ -711,7 +710,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                                 } catch (e: MissingPermissionException) {
                                     throw IllegalStateException(e)
                                 }
-                            }
+                            }*/
                         }
                     }
                 })
@@ -745,7 +744,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
 
                         // Start CameraService
                         lifecycleScope.launch {
-                            if (withContext(Dispatchers.IO) { cameraSettings.cameraEnabledFlow.first() }) {
+                            /*if (withContext(Dispatchers.IO) { cameraSettings.cameraEnabledFlow.first() }) {
                                 Log.d(Constants.TAG, "CameraServiceRequested")
                                 try {
                                     startCameraService(measurementIdentifier)
@@ -754,7 +753,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                                 } catch (e: MissingPermissionException) {
                                     throw java.lang.IllegalStateException(e)
                                 }
-                            }
+                            }*/
                         }
                     }
                 })
@@ -792,7 +791,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
         val exposureValueIso100 = cameraSettings.getStaticExposureValueBlocking()*/
 
         // Set default setting as this UI does not allow the user to change it.
-        val cameraInfo = CameraInfo(requireContext())
+        /*val cameraInfo = CameraInfo(requireContext())
         val minFocusDistance = if (cameraInfo.hyperFocalDistance != null) {
             cameraInfo.hyperFocalDistance!!
         } else {
@@ -821,7 +820,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                 override fun startUpFinished(measurementIdentifier: Long) {
                     Log.v(Constants.TAG, "startCameraService: CameraService startUpFinished")
                 }
-            })
+            })*/
     }
 
     private fun isRestrictionActive(): Boolean {
@@ -1075,7 +1074,7 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
             })
     }
 
-    private fun checkAndStopCameraCapturing(capturingStopped: Boolean, updateUi: Boolean, pause: Boolean) {
+    /*private fun checkAndStopCameraCapturing(capturingStopped: Boolean, updateUi: Boolean, pause: Boolean) {
         cameraService.isRunning(
             DataCapturingService.IS_RUNNING_CALLBACK_TIMEOUT,
             TimeUnit.MILLISECONDS,
@@ -1133,9 +1132,9 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
                 }
             }
         )
-    }
+    }*/
 
-    override fun onNewPictureAcquired(picturesCaptured: Int) {
+    /*override fun onNewPictureAcquired(picturesCaptured: Int) {
         Log.d(TAG, "onNewPictureAcquired")
         /*val text =
             context!!.getString(de.cyface.camera_service.R.string.camera_images) + " " + picturesCaptured
@@ -1149,5 +1148,5 @@ class CapturingFragment : Fragment(), DataCapturingListener, CameraListener {
 
     override fun onVideoStopped() {
         Log.d(TAG, "onVideoStopped")
-    }
+    }*/
 }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/UnInterestedListener.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/UnInterestedListener.kt
@@ -18,7 +18,7 @@
  */
 package de.cyface.app.r4r.capturing
 
-import android.content.Context
+/*import android.content.Context
 import android.location.Location
 import de.cyface.camera_service.background.ParcelableCapturingProcessListener
 import kotlinx.coroutines.CoroutineScope
@@ -60,4 +60,4 @@ class UnInterestedListener : ParcelableCapturingProcessListener {
     override fun shallStop(context: Context) {
         // Nothing to do
     }
-}
+}*/

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/CameraSwitchHandler.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/CameraSwitchHandler.kt
@@ -34,14 +34,14 @@ import kotlinx.coroutines.launch
  * @version 2.0.2
  * @since 2.0.0
  */
-class CameraSwitchHandler(
+/*class CameraSwitchHandler(
     private val viewModel: SettingsViewModel,
     private val fragment: SettingsFragment
 ) : CompoundButton.OnCheckedChangeListener {
     override fun onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean) {
-        if (viewModel.cameraEnabled.value == isChecked) {
+        /*if (viewModel.cameraEnabled.value == isChecked) {
             return
-        }
+        }*/
 
         // No rear camera found
         val context = fragment.requireContext()
@@ -76,4 +76,4 @@ class CameraSwitchHandler(
             return
         }
     }
-}
+}*/

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsFragment.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsFragment.kt
@@ -32,13 +32,12 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import de.cyface.app.r4r.Application
 import de.cyface.app.r4r.BuildConfig
-import de.cyface.app.r4r.CameraServiceProvider
 import de.cyface.app.r4r.R
 import de.cyface.app.r4r.databinding.FragmentSettingsBinding
 import de.cyface.app.utils.ServiceProvider
 import de.cyface.app.utils.SharedConstants
 import de.cyface.app.utils.trips.incentives.AuthExceptionListener
-import de.cyface.camera_service.CameraInfo
+//import de.cyface.camera_service.CameraInfo
 import de.cyface.datacapturing.CyfaceDataCapturingService
 import de.cyface.synchronization.Auth
 import io.sentry.Sentry
@@ -97,10 +96,10 @@ class SettingsFragment : Fragment() {
                 if (allGranted) {
                     //showCameraModeDialog(this) - no Dialog needed in r4r
                     viewModel.viewModelScope.launch {
-                        viewModel.setCameraEnabled(true)
+                        //viewModel.setCameraEnabled(true)
                     }
                 } else {
-                    Toast.makeText(
+                    /*Toast.makeText(
                         context,
                         requireContext().getString(
                             de.cyface.camera_service.R.string.camera_service_off_missing_permissions
@@ -111,7 +110,7 @@ class SettingsFragment : Fragment() {
                     viewModel.viewModelScope.launch {
                         viewModel.setCameraEnabled(true)
                         viewModel.setCameraEnabled(false)
-                    }
+                    }*/
                 }
             }
         }
@@ -127,17 +126,17 @@ class SettingsFragment : Fragment() {
         } else {
             throw RuntimeException("Context does not support the Fragment, implement ServiceProvider")
         }
-        val cameraSettings =
+        /*val cameraSettings =
             if (activity is CameraServiceProvider) {
                 (activity as CameraServiceProvider).cameraSettings
             } else {
                 throw RuntimeException("Context doesn't support the Fragment, implement `CameraServiceProvider`")
-            }
+            }*/
 
         // Initialize ViewModel
         viewModel = ViewModelProvider(
             this,
-            SettingsViewModelFactory(Application.appSettings, cameraSettings)
+            SettingsViewModelFactory(Application.appSettings/*, cameraSettings*/)
         )[SettingsViewModel::class.java]
     }
 
@@ -167,12 +166,12 @@ class SettingsFragment : Fragment() {
             showDeleteAccountConfirmationDialog()
         }
         /** camera settings **/
-        binding.cameraEnabledSwitch.setOnCheckedChangeListener(
+        /*binding.cameraEnabledSwitch.setOnCheckedChangeListener(
             CameraSwitchHandler(
                 viewModel,
                 this
             )
-        )
+        )*/
 
         // Observe view model and update UI
         /** app settings **/
@@ -187,7 +186,7 @@ class SettingsFragment : Fragment() {
             }
         }
         /** camera settings **/
-        viewModel.cameraEnabled.observe(viewLifecycleOwner) { cameraEnabled ->
+        /*viewModel.cameraEnabled.observe(viewLifecycleOwner) { cameraEnabled ->
             run {
                 binding.cameraEnabledSwitch.isChecked = cameraEnabled
                 //binding.cameraSettingsWrapper.visibility = if (cameraEnabled) View.VISIBLE else View.GONE
@@ -211,7 +210,7 @@ class SettingsFragment : Fragment() {
                     */
                 }
             }
-        }
+        }*/
 
         return binding.root
     }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsViewModel.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsViewModel.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import de.cyface.camera_service.settings.CameraSettings
+//import de.cyface.camera_service.settings.CameraSettings
 import de.cyface.utils.settings.AppSettings
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -50,7 +50,7 @@ import kotlinx.coroutines.launch
  */
 class SettingsViewModel(
     private val appSettings: AppSettings,
-    private val cameraSettings: CameraSettings,
+    //private val cameraSettings: CameraSettings,
 ) : ViewModel() {
 
     /** app settings **/
@@ -61,7 +61,7 @@ class SettingsViewModel(
     private val _cameraEnabled = MutableLiveData<Boolean>()
 
     /** camera settings  **/
-    val cameraEnabled: LiveData<Boolean> = cameraSettings.cameraEnabledFlow.asLiveData()
+    //val cameraEnabled: LiveData<Boolean> = cameraSettings.cameraEnabledFlow.asLiveData()
 
     /**
      * {@code True} if the camera allows to control the sensors (focus, exposure, etc.) manually.
@@ -78,7 +78,7 @@ class SettingsViewModel(
             _centerMap.value = appSettings.centerMapFlow.first()
             _upload.value = appSettings.uploadEnabledFlow.first()
             /** camera settings  **/
-            _cameraEnabled.value = cameraSettings.cameraEnabledFlow.first()
+            //_cameraEnabled.value = cameraSettings.cameraEnabledFlow.first()
         }
     }
 
@@ -94,8 +94,8 @@ class SettingsViewModel(
     }
 
     /** camera settings **/
-    suspend fun setCameraEnabled(cameraEnabled: Boolean) {
+    /*suspend fun setCameraEnabled(cameraEnabled: Boolean) {
         cameraSettings.setCameraEnabled(cameraEnabled)
         _cameraEnabled.postValue(cameraEnabled)
-    }
+    }*/
 }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsViewModelFactory.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/capturing/settings/SettingsViewModelFactory.kt
@@ -20,7 +20,7 @@ package de.cyface.app.r4r.capturing.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import de.cyface.camera_service.settings.CameraSettings
+//import de.cyface.camera_service.settings.CameraSettings
 import de.cyface.utils.settings.AppSettings
 
 /**
@@ -34,13 +34,13 @@ import de.cyface.utils.settings.AppSettings
  */
 class SettingsViewModelFactory(
     private val appSettings: AppSettings,
-    private val cameraSettings: CameraSettings,
+    //private val cameraSettings: CameraSettings,
 ) :
     ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return SettingsViewModel(appSettings, cameraSettings) as T
+            return SettingsViewModel(appSettings/*, cameraSettings*/) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/ui/r4r/src/main/kotlin/de/cyface/app/r4r/notification/CameraEventHandler.kt
+++ b/ui/r4r/src/main/kotlin/de/cyface/app/r4r/notification/CameraEventHandler.kt
@@ -33,9 +33,9 @@ import de.cyface.app.utils.SharedConstants.CAMERA_ACCESS_LOST_NOTIFICATION_ID
 import de.cyface.app.utils.SharedConstants.NOTIFICATION_CHANNEL_ID_RUNNING
 import de.cyface.app.utils.SharedConstants.NOTIFICATION_CHANNEL_ID_WARNING
 import de.cyface.app.utils.SharedConstants.PICTURE_CAPTURING_DECREASED_NOTIFICATION_ID
-import de.cyface.camera_service.background.BackgroundService
-import de.cyface.camera_service.foreground.NotificationStrategy
-import kotlinx.parcelize.Parcelize
+//import de.cyface.camera_service.background.BackgroundService
+//import de.cyface.camera_service.foreground.NotificationStrategy
+//import kotlinx.parcelize.Parcelize
 
 /**
  * A [NotificationStrategy] to respond to specified events triggered by the
@@ -43,8 +43,8 @@ import kotlinx.parcelize.Parcelize
  *
  * @author Armin Schnabel
  */
-@Parcelize
-class CameraEventHandler : NotificationStrategy {
+//@Parcelize
+/*class CameraEventHandler : NotificationStrategy {
     /**
      * A [Notification] shown when the [BackgroundService] triggered the 'camera error' event.
      *
@@ -241,4 +241,4 @@ class CameraEventHandler : NotificationStrategy {
             }
         }
     }
-}
+}*/

--- a/ui/r4r/src/main/res/layout/fragment_settings.xml
+++ b/ui/r4r/src/main/res/layout/fragment_settings.xml
@@ -62,13 +62,15 @@
         app:layout_constraintRight_toRightOf="parent" />
       </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <!-- camera enabled -->
+    <!-- camera enabled - HIDDEN FOR PUBLIC RELEASE -->
+    <!-- when u enable it again, you also need to chang layout_constraintTop_toBottomOf of the next component -->
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <!--androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/camera_enabled_wrapper"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal"
+      android:visibility="gone"
       app:layout_constraintLeft_toLeftOf="parent"
       app:layout_constraintTop_toBottomOf="@id/upload">
 
@@ -86,7 +88,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout-->
 
     <!-- account deletion -->
 
@@ -95,7 +97,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       app:layout_constraintLeft_toLeftOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/camera_enabled_wrapper"
+      app:layout_constraintTop_toBottomOf="@id/upload"
       android:orientation="horizontal">
       <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
If camera was enabled we would need to explain in Play Store why.
As this is currently only an internal feature on the RFR App, I disable it so I'm able to make a final release.
The release is necessary as our Auth Server moved.