### PR TITLE
[LEIP-461] Treat 403 on already-uploaded attachments as success

### DIFF
--- a/ui/digural/src/main/kotlin/de/cyface/app/digural/upload/WebdavUploader.kt
+++ b/ui/digural/src/main/kotlin/de/cyface/app/digural/upload/WebdavUploader.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.util.Log
 import com.thegrizzlylabs.sardineandroid.Sardine
 import com.thegrizzlylabs.sardineandroid.impl.OkHttpSardine
+import com.thegrizzlylabs.sardineandroid.impl.SardineException
 import de.cyface.app.digural.MainActivity.Companion.TAG
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -334,12 +335,21 @@ class WebdavUploader(
                     fileNamePrefix(uploadable.deviceId(), uploadable.measurementId())
                 )
                 val attachmentUri = "$uploadDir/$diguralFileName"
-                // No `exists()` check: a redundant HEAD per attachment doubled round-trips in
-                // the hot path. Per-attachment idempotency is already tracked in AttachmentDao
-                // (SAVED -> SYNCED). WebDAV PUT overwrites if the file happens to be on the
-                // server already, which is acceptable.
+                // No pre-upload exists() check: a redundant HEAD per attachment doubles
+                // round-trips in the hot path. Per-attachment idempotency is tracked in
+                // AttachmentDao (SAVED -> SYNCED). Overwrite via PUT does not seem to be
+                // allowed on the Digural WebDAV, so on 403 we check existence and treat as
+                // successful to avoid an ever-growing list of retries on each sync cycle.
                 Log.d(TAG, "Upload attachment: $diguralFileName ...")
-                sardine.put(attachmentUri, file, "application/octet-stream")
+                try {
+                    sardine.put(attachmentUri, file, "application/octet-stream")
+                } catch (e: SardineException) {
+                    if (e.statusCode == 403 && sardine.exists(attachmentUri)) {
+                        Log.i(TAG, "Attachment already exists on server, marking as synced: $diguralFileName")
+                    } else {
+                        throw e
+                    }
+                }
             }
             de.cyface.uploader.Result.UPLOAD_SUCCESSFUL
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {


### PR DESCRIPTION
## Summary
When a WebDAV PUT is interrupted after the server writes the file but before the client receives the response, the attachment stays SAVED locally. On retry, Nextcloud returns 403 Forbidden instead of overwriting. These files are confirmed complete on the server (identical byte sizes verified manually).

Now when a PUT gets 403, do a follow-up `sardine.exists()` check. If the file is already on the server, treat it as successfully uploaded (flows through to mark SYNCED) instead of throwing UploadFailed and retrying forever.

The exists() check only happens on the error path (403), not on every upload -- no performance impact for normal operations.

## Test plan
- [ ] Deploy and verify the repeated 403 errors stop appearing in logcat
- [ ] Verify attachments transition from SAVED to SYNCED for already-uploaded files
- [ ] Verify genuinely failing uploads (non-403, or 403 where file doesn't exist) still throw correctly